### PR TITLE
修复读取的用户名格式错误

### DIFF
--- a/goodluck/user.py
+++ b/goodluck/user.py
@@ -13,6 +13,7 @@ def get_username():
 
 
 def get_permission_info(username):
+    username = username.split('-')[0]
     content = requests.get(f"http://10.19.124.11:8899/permission?username={username}").json()
     permissions = []
     for info in content['permission']:


### PR DESCRIPTION
get_permission_info(username) 方法中username含有当前的节点信息如“lirongjie-admin”，用str.split去掉-之后的内容